### PR TITLE
fix generated env vars name

### DIFF
--- a/src/model/site_config.cr
+++ b/src/model/site_config.cr
@@ -58,6 +58,7 @@ module Wsman
       def full_hosts(base_domain)
         result = Hash(String, String).new
         @hosts.each do |host, _folder|
+          host = host.gsub(/[^0-9a-z]/i, '_')
           result[host.upcase] = "#{host}.#{base_domain}"
         end
         result


### PR DESCRIPTION
Change non alphanumerical characters to underscore in env var names